### PR TITLE
Update safe_data_management and safe_technology_engineering

### DIFF
--- a/docs/competency_framework/safe_data_management.md
+++ b/docs/competency_framework/safe_data_management.md
@@ -4,11 +4,14 @@ This domain covers all aspects of data handling, processing, governance, and eng
 
 ## Data Governance
 
-Data Governance establishes frameworks and processes for ensuring data quality, security, and proper management throughout its lifecycle. This subdomain encompasses classification of sensitive data, tracking data lineage and provenance, and implementing quality management practices that maintain data integrity, accuracy, and compliance with organisational policies while providing visibility into data origins and transformations.
+Data Governance establishes frameworks and processes for ensuring data quality, security, and proper management throughout its lifecycle.
+This subdomain encompasses classification of sensitive data, tracking data lineage and provenance, and implementing quality management practices that maintain data integrity, accuracy, and compliance with organisational policies while providing visibility into data origins and transformations.
 
 ### Data Integrity
 
-Ensures that data remains accurate, consistent, and unaltered throughout its lifecycle. Involves implementing mechanisms such as checksums, hash validation, and digital signatures to detect and prevent unauthorised modification or corruption. Requires regular integrity checks, monitoring, and alerting, as well as procedures for remediation in the event of integrity violations.
+Ensures that data remains accurate, consistent, and unaltered throughout its lifecycle.
+Involves implementing mechanisms such as checksums, hash validation, and digital signatures to detect and prevent unauthorised modification or corruption.
+Requires regular integrity checks, monitoring, and alerting, as well as procedures for remediation in the event of integrity violations.
 
 === ":material-battery-10: Entry Level"
 
@@ -30,27 +33,33 @@ Ensures that data remains accurate, consistent, and unaltered throughout its lif
 
 ### Data Cataloguing & Discovery
 
-Creates and maintains systems that enable researchers to find and understand available datasets. Involves documenting datasets with appropriate metadata, implementing catalogue systems, developing metadata standards, ensuring catalogue accuracy and usability, and architecting enterprise discovery strategies. Requires establishing governance frameworks and enhancing data reusability.
+Creates and maintains systems that enable researchers to find and understand available datasets in line with FAIR (Findable, Accessible, Interoperable, and Reusable) principles.
+Involves documenting datasets with appropriate metadata, implementing catalogue systems, developing metadata standards, ensuring catalogue accuracy and usability, and architecting enterprise discovery solutions.
+Requires establishing governance frameworks and enhancing data reusability.
 
 === ":material-battery-10: Entry Level"
 
     - Understands the purpose and structure of data catalogues
     - Familiar with metadata standards and practices
+    - Familiar with common data cataloguing tools
 
 === ":material-battery-50: Mid Level"
 
     - Implements and maintains data catalogue systems
     - Develops metadata standards and collection processes
 
+
 === ":material-battery-90: Senior Level"
 
-    - Architects enterprise data catalogue strategies and implementations
+    - Architects enterprise-wide data catalogue implementations
     - Establishes governance frameworks for metadata management
     - Leads initiatives to enhance data discovery and reuse
 
 ### Data Classification & Sensitivity
 
-Implements frameworks for categorising data based on sensitivity and security requirements. Involves understanding different data types, applying appropriate classification labels, designing handling procedures, conducting reviews, and developing organisational policies. Requires implementing classification systems and leading risk assessment initiatives across the organisation.
+Implements frameworks for categorising data based on sensitivity and security requirements.
+Involves understanding different data types, applying appropriate classification labels, designing handling procedures, conducting reviews, and developing organisational policies.
+Requires implementing classification systems and leading risk assessment initiatives across the organisation.
 
 === ":material-battery-10: Entry Level"
 
@@ -72,7 +81,9 @@ Implements frameworks for categorising data based on sensitivity and security re
 
 ### Data Lineage & Provenance
 
-Tracks and documents the origins, movements, and transformations of data throughout systems. Involves maintaining metadata documentation, implementing lineage tools, verifying data provenance, analysing quality issues, and architecting enterprise-wide systems. Requires developing governance frameworks that maintain visibility of sensitive data across multiple systems.
+Tracks and documents the origins, movements, and transformations of data throughout systems.
+Involves maintaining metadata documentation, implementing lineage tools, verifying data provenance, analysing quality issues, and architecting enterprise-wide systems.
+Requires developing governance frameworks that maintain visibility of sensitive data across multiple systems.
 
 === ":material-battery-10: Entry Level"
 
@@ -94,7 +105,9 @@ Tracks and documents the origins, movements, and transformations of data through
 
 ### Data Quality Management
 
-Ensures the accuracy, completeness, and reliability of data within secure environments. Involves understanding quality dimensions, performing validation, designing quality frameworks, developing metrics, implementing automated validation, and establishing enterprise-wide strategies. Requires leading quality improvement initiatives and developing advanced measurement and remediation approaches.
+Ensures the accuracy, completeness, and reliability of data within secure environments.
+Involves understanding quality dimensions, performing validation, designing quality frameworks, developing metrics, implementing automated validation, and establishing enterprise-wide strategies.
+Requires leading quality improvement initiatives and developing advanced measurement and remediation approaches.
 
 === ":material-battery-10: Entry Level"
 
@@ -110,7 +123,7 @@ Ensures the accuracy, completeness, and reliability of data within secure enviro
 
 === ":material-battery-90: Senior Level"
 
-    - Establishes enterprise data quality strategies and governance
+    - Establishes enterprise data quality management policies
     - Leads data quality improvement initiatives across the organisation
     - Develops advanced data quality measurement and remediation approaches
 
@@ -121,7 +134,9 @@ This subdomain covers the development of secure data pipelines, management of da
 
 ### Data Pipeline Development
 
-Builds and maintains processes that extract, transform, and load data securely between systems. Involves developing ETL processes, designing secure pipelines for various data types, implementing error handling, monitoring data flows, and optimising performance. Requires architecting complex systems at enterprise scale and establishing best practices for secure data processing.
+Builds and maintains processes that extract, transform, and load data securely between systems.
+Involves developing ETL processes, designing secure pipelines for various data types, implementing error handling, monitoring data flows, and optimising performance.
+Requires architecting complex systems at enterprise scale and establishing best practices for secure data processing.
 
 === ":material-battery-10: Entry Level"
 
@@ -143,7 +158,9 @@ Builds and maintains processes that extract, transform, and load data securely b
 
 ### Data Storage & Database Management
 
-Designs and maintains secure database systems for storing and retrieving sensitive data. Involves understanding database types, performing SQL operations, designing secure schemas, implementing access policies, optimising performance, and architecting enterprise storage strategies. Requires developing governance frameworks and leading database modernisation initiatives.
+Designs and maintains secure database systems for storing and retrieving sensitive data.
+Involves understanding database types, performing SQL operations, designing secure schemas, implementing access policies, optimising performance, and architecting enterprise storage solutions.
+Requires developing governance frameworks and leading database modernisation initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -159,13 +176,15 @@ Designs and maintains secure database systems for storing and retrieving sensiti
 
 === ":material-battery-90: Senior Level"
 
-    - Architects enterprise data storage strategies across platforms
+    - Architects enterprise data storage solutions across platforms
     - Develops database governance and security frameworks
     - Leads database modernisation and migration initiatives
 
 ### Data Models & Standardisation
 
-Enables the secure and effective use of standardised data models such as FHIR and OMOP within secure data environments. Involves understanding platform and integration requirements, assessing platform capabilities, supporting configuration and adaptation for model adoption, and ensuring compliance with relevant standards. Requires developing strategies to enhance interoperability, security, and governance for standardised data models across platforms.
+Enables the secure and effective use of standardised data models such as FHIR and OMOP within secure data environments.
+Involves understanding platform and integration requirements, assessing platform capabilities, supporting configuration and adaptation for model adoption, and ensuring compliance with relevant standards.
+Requires developing approaches to enhance interoperability, security, and governance for standardised data models across platforms.
 
 === ":material-battery-10: Entry Level"
 
@@ -181,13 +200,15 @@ Enables the secure and effective use of standardised data models such as FHIR an
 
 === ":material-battery-90: Senior Level"
 
-    - Develops enterprise data modelling strategies and governance
+    - Develops enterprise data modelling approaches
     - Establishes processes for maintaining and evolving data models
     - Leads initiatives to harmonise data models across systems
 
 ### Event-Driven Data Processing
 
-Implements systems that process data in real-time based on events and triggers. Involves understanding event-driven architecture, working with streaming platforms like Kafka, implementing event producers and consumers, designing specialised pipelines, and ensuring data quality. Requires architecting enterprise event strategies and designing high-throughput, reliable processing systems.
+Implements systems that process data in real-time based on events and triggers.
+Involves understanding event-driven architecture, working with streaming platforms like Kafka, implementing event producers and consumers, designing specialised pipelines, and ensuring data quality.
+Requires architecting enterprise-scale, high-throughput, reliable event-driven processing systems.
 
 === ":material-battery-10: Entry Level"
 
@@ -203,13 +224,15 @@ Implements systems that process data in real-time based on events and triggers. 
 
 === ":material-battery-90: Senior Level"
 
-    - Architects enterprise event-driven data strategies
+    - Architects enterprise event-driven data systems
     - Designs high-throughput, reliable event processing systems
     - Leads innovation in event-based analytical systems
 
 ### Encryption Standards & Implementation
 
-Implements cryptographic solutions to protect sensitive data throughout its lifecycle in secure environments. Involves understanding encryption methods, configuring cryptographic systems, managing encryption keys, and ensuring compliance with security standards. Requires designing enterprise encryption frameworks, implementing advanced cryptographic techniques, and establishing organisational policies that maintain data confidentiality and integrity.
+Implements cryptographic solutions to protect sensitive data throughout its lifecycle in secure environments.
+Involves understanding encryption methods, configuring cryptographic systems, managing encryption keys, and ensuring compliance with security standards.
+Requires designing enterprise encryption frameworks, implementing advanced cryptographic techniques, and establishing organisational policies that maintain data confidentiality and integrity.
 
 === ":material-battery-10: Entry Level"
 
@@ -231,7 +254,9 @@ Implements cryptographic solutions to protect sensitive data throughout its life
 
 ### Data Backups
 
-Ensures data availability and recoverability through systematic backup and restoration processes. Involves understanding backup strategies, implementing automated backup systems, managing retention policies, and designing recovery procedures. Requires architecting resilient backup infrastructures, establishing security protocols, and developing enterprise-wide policies that minimise data loss and downtime while maintaining compliance with regulatory requirements.
+Ensures data availability and recoverability through systematic backup and restoration processes.
+Involves understanding backup plans, implementing automated backup systems, managing retention policies, and designing recovery procedures.
+Requires architecting resilient backup infrastructures, establishing security protocols, and developing enterprise-wide policies that minimise data loss and downtime while maintaining compliance with regulatory requirements.
 
 === ":material-battery-10: Entry Level"
 
@@ -241,19 +266,21 @@ Ensures data availability and recoverability through systematic backup and resto
 
 === ":material-battery-50: Mid Level"
 
-    - Configures and optimises backup strategies for different environments (on-premises, cloud, hybrid)
+    - Configures and optimises backup plans for different environments (on-premises, cloud, hybrid)
     - Implements scripts and tools to streamline backup operations and reduce manual intervention
     - Ensures backups meet regulatory requirements and conducts regular integrity checks
 
 === ":material-battery-90: Senior Level"
 
     - Designs scalable, resilient backup architectures for large-scale systems
-    - Leads the development of recovery strategies to minimise downtime and data loss
+    - Leads the development of recovery plans to minimise downtime and data loss
     - Establishes policies for backup security, encryption, and compliance with industry standards
 
 ### Data Retention & Disposal
 
-Manages the secure lifecycle of data from creation to disposal, ensuring compliance with regulatory requirements and organisational policies. Involves understanding storage types and data lifecycles, implementing retention strategies, designing secure disposal processes, and establishing governance frameworks. Requires developing enterprise-wide policies that balance performance, cost, and compliance while maintaining data accessibility and security throughout the retention period.
+Manages the secure lifecycle of data from creation to disposal, ensuring compliance with regulatory requirements and organisational policies.
+Involves understanding storage types and data lifecycles, implementing retention strategies, designing secure disposal processes, and establishing governance frameworks.
+Requires developing enterprise-wide policies that balance performance, cost, and compliance while maintaining data accessibility and security throughout the retention period.
 
 === ":material-battery-10: Entry Level"
 
@@ -263,7 +290,7 @@ Manages the secure lifecycle of data from creation to disposal, ensuring complia
 
 === ":material-battery-50: Mid Level"
 
-    - Implements data lifecycle strategies that balance retention requirements with storage efficiency
+    - Implements data lifecycle approaches that balance retention requirements with storage efficiency
     - Applies data access policies, encryption, and secure storage practices to protect retained data from unauthorised access
     - Conducts data usage audits and ensures adherence to regulatory standards (GDPR, HIPAA)
 
@@ -275,7 +302,9 @@ Manages the secure lifecycle of data from creation to disposal, ensuring complia
 
 ### Data Migration
 
-Ensures the secure, reliable, and efficient transfer of data between systems, storage solutions, or environments. Involves planning and executing migrations to minimise downtime and data loss, validating data integrity before and after migration, and ensuring compliance with security and regulatory requirements. Requires implementing automated migration workflows, monitoring migration processes, and remediating issues as they arise.
+Ensures the secure, reliable, and efficient transfer of data between systems, storage solutions, or environments.
+Involves planning and executing migrations to minimise downtime and data loss, validating data integrity before and after migration, and ensuring compliance with security and regulatory requirements.
+Requires implementing automated migration workflows, monitoring migration processes, and remediating issues as they arise.
 
 === ":material-battery-10: Entry Level"
 
@@ -292,7 +321,7 @@ Ensures the secure, reliable, and efficient transfer of data between systems, st
 
 === ":material-battery-90: Senior Level"
 
-    - Designs enterprise-wide data migration strategies and policies
+    - Designs enterprise-wide data migration approaches and policies
     - Leads complex or large-scale migration projects with minimal downtime
     - Ensures compliance with security and regulatory requirements during migration
     - Develops and oversees remediation plans for migration failures or data discrepancies

--- a/docs/competency_framework/safe_technology_engineering.md
+++ b/docs/competency_framework/safe_technology_engineering.md
@@ -4,11 +4,13 @@ This domain covers the technical implementation and maintenance of secure system
 
 ## Software Engineering
 
-Software Engineering applies structured approaches to developing and maintaining secure, high-quality code for research environments. This subdomain encompasses implementing appropriate software development lifecycle methodologies, incorporating secure coding practices that protect against common vulnerabilities, implementing comprehensive testing and quality assurance processes, and creating well-documented, reusable code that enhances maintainability while enabling knowledge sharing across development teams.
+Software Engineering applies structured approaches to developing and maintaining secure, high-quality code for research environments.
+This subdomain encompasses implementing appropriate software development lifecycle methodologies, incorporating secure coding practices that protect against common vulnerabilities, implementing comprehensive testing and quality assurance processes, and creating well-documented, reusable code that enhances maintainability while enabling knowledge sharing across development teams.
 
 ### Software Development Lifecycle
 
-Applies structured approaches to developing and maintaining software throughout its lifecycle. Involves following established processes, using version control systems, implementing bug fixes, applying methodologies appropriate to context, managing code repositories, designing secure features, establishing best practices, leading architectural decisions, and mentoring team members in engineering excellence.
+Applies structured approaches to developing and maintaining software throughout its lifecycle.
+Involves following established processes, using version control systems, implementing bug fixes, applying methodologies appropriate to context, managing code repositories, designing secure features, establishing best practices, leading architectural decisions, and mentoring team members in engineering excellence.
 
 === ":material-battery-10: Entry Level"
 
@@ -30,7 +32,8 @@ Applies structured approaches to developing and maintaining software throughout 
 
 ### Secure Coding Practices
 
-Develops software with security built into the code itself. Involves understanding common vulnerabilities like OWASP Top 10, applying input validation and error handling, following secure coding guidelines, identifying and mitigating security issues, implementing secure authentication and authorization, conducting security-focused code reviews, and developing organizational standards.
+Develops software with security built into the code itself.
+Involves understanding common vulnerabilities like OWASP Top 10, applying input validation and error handling, following secure coding guidelines, identifying and mitigating security issues, implementing secure authentication and authorization, conducting security-focused code reviews, and developing organizational standards.
 
 === ":material-battery-10: Entry Level"
 
@@ -52,7 +55,8 @@ Develops software with security built into the code itself. Involves understandi
 
 ### Testing & Quality Assurance
 
-Validates software functionality, security, and performance before deployment. Involves creating unit tests, using testing frameworks, executing test plans, designing comprehensive approaches, implementing automated pipelines, analyzing results to improve quality, establishing processes and standards, implementing advanced testing, and driving continuous improvement initiatives.
+Validates software functionality, security, and performance before deployment.
+Involves creating unit tests, using testing frameworks, executing test plans, designing comprehensive approaches, implementing automated pipelines, analyzing results to improve quality, establishing processes and standards, implementing advanced testing, and driving continuous improvement initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -74,7 +78,8 @@ Validates software functionality, security, and performance before deployment. I
 
 ### Microservices & API Design
 
-Develops loosely coupled, independently deployable services that communicate via APIs. Involves understanding microservices principles, working with API concepts and documentation, designing appropriate service boundaries, implementing secure API gateways, developing versioning approaches, architecting enterprise API frameworks, establishing best practices, and leading API security initiatives.
+Develops loosely coupled, independently deployable services that communicate via APIs.
+Involves understanding microservices principles, working with API concepts and documentation, designing appropriate service boundaries, implementing secure API gateways, developing versioning approaches, architecting enterprise API frameworks, establishing best practices, and leading API security initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -96,7 +101,8 @@ Develops loosely coupled, independently deployable services that communicate via
 
 ### Code Documentation & Reusability
 
-Creates understandable, maintainable, and reusable code. Involves writing clear comments explaining functionality, following documentation patterns, creating comprehensive explanations, designing for reusability with appropriate abstraction, implementing self-documenting principles, establishing organizational standards, developing reuse approaches, and creating knowledge sharing frameworks.
+Creates understandable, maintainable, and reusable code.
+Involves writing clear comments explaining functionality, following documentation patterns, creating comprehensive explanations, designing for reusability with appropriate abstraction, implementing self-documenting principles, establishing organizational standards, developing reuse approaches, and creating knowledge sharing frameworks.
 
 === ":material-battery-10: Entry Level"
 
@@ -118,7 +124,8 @@ Creates understandable, maintainable, and reusable code. Involves writing clear 
 
 ### Artefact Management
 
-Securely stores, distributes, and controls access to software artefacts including container images, helm charts, and package repositories. Involves understanding artefact concepts, accessing repositories following procedures, working with vulnerability scanning, implementing secure registries, controlling access and scanning for threats, managing distributions, developing enterprise frameworks, establishing governance processes, and leading security initiatives.
+Securely stores, distributes, and controls access to software artefacts including container images, helm charts, and package repositories.
+Involves understanding artefact concepts, accessing repositories following procedures, working with vulnerability scanning, implementing secure registries, controlling access and scanning for threats, managing distributions, developing enterprise frameworks, establishing governance processes, and leading security initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -140,11 +147,13 @@ Securely stores, distributes, and controls access to software artefacts includin
 
 ## Infrastructure & Deployment
 
-Infrastructure & Deployment establishes the foundation for secure, scalable research environments. This subdomain focuses on designing and managing cloud resources with appropriate security controls, implementing containerization and orchestration technologies that enable portable, isolated application environments, and creating secure network architectures with proper segmentation and access controls that collectively provide the technical infrastructure needed for protected data processing and analysis.
+Infrastructure & Deployment establishes the foundation for secure, scalable research environments.
+This subdomain focuses on designing and managing cloud resources with appropriate security controls, implementing containerization and orchestration technologies that enable portable, isolated application environments, and creating secure network architectures with proper segmentation and access controls that collectively provide the technical infrastructure needed for protected data processing and analysis.
 
 ### Cloud Infrastructure Management
 
-Designs, deploys, and manages cloud resources for secure data environments. Involves working with major providers like AWS, Azure, and GCP, provisioning resources following patterns, implementing infrastructure as code, designing secure architectures, implementing monitoring and scaling, architecting enterprise solutions, developing governance frameworks, and leading cloud transformation initiatives.
+Designs, deploys, and manages cloud resources for secure data environments.
+Involves working with major providers like AWS, Azure, and GCP, provisioning resources following patterns, implementing infrastructure as code, designing secure architectures, implementing monitoring and scaling, architecting enterprise solutions, developing governance frameworks, and leading cloud transformation initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -166,7 +175,8 @@ Designs, deploys, and manages cloud resources for secure data environments. Invo
 
 ### Containerization & Orchestration
 
-Packages and manages applications in isolated, portable environments. Involves understanding container concepts, working with Docker and container registries, designing container-based architectures, implementing orchestration with Kubernetes or similar platforms, creating CI/CD pipelines, architecting enterprise frameworks, implementing advanced security features, and establishing compliance processes.
+Packages and manages applications in isolated, portable environments.
+Involves understanding container concepts, working with Docker and container registries, designing container-based architectures, implementing orchestration with Kubernetes or similar platforms, creating CI/CD pipelines, architecting enterprise frameworks, implementing advanced security features, and establishing compliance processes.
 
 === ":material-battery-10: Entry Level"
 
@@ -188,7 +198,8 @@ Packages and manages applications in isolated, portable environments. Involves u
 
 ### Network Architecture
 
-Designs and implements secure networks for data environments. Involves understanding networking concepts like IP addressing and routing, configuring network settings, designing secure architectures with appropriate segmentation, implementing VPCs and access controls, troubleshooting issues, architecting complex multi-environment solutions, and developing network security policies.
+Designs and implements secure networks for data environments.
+Involves understanding networking concepts like IP addressing and routing, configuring network settings, designing secure architectures with appropriate segmentation, implementing VPCs and access controls, troubleshooting issues, architecting complex multi-environment solutions, and developing network security policies.
 
 === ":material-battery-10: Entry Level"
 
@@ -210,7 +221,8 @@ Designs and implements secure networks for data environments. Involves understan
 
 ### Encryption & Key Management
 
-Protects data at rest and in transit using secure algorithms and robust key management practices. Involves understanding encryption concepts, implementing encryption solutions, selecting appropriate algorithms, generating and storing keys securely, managing key lifecycles, implementing access controls, developing enterprise frameworks, establishing governance frameworks, and leading security enhancement initiatives.
+Protects data at rest and in transit using secure algorithms and robust key management practices.
+Involves understanding encryption concepts, implementing encryption solutions, selecting appropriate algorithms, generating and storing keys securely, managing key lifecycles, implementing access controls, developing enterprise frameworks, establishing governance frameworks, and leading security enhancement initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -232,11 +244,13 @@ Protects data at rest and in transit using secure algorithms and robust key mana
 
 ## System Architecture
 
-System Architecture establishes the foundational design principles for secure, scalable, and maintainable research environments. This subdomain encompasses creating secure environment designs with [defense-in-depth](https://en.wikipedia.org/wiki/Defense_in_depth_(computing)) approaches, developing microservices and API architectures that enable modular and flexible systems, implementing approaches for scalability and performance under varying workloads, creating robust enterprise solutions that meet critical requirements, and adopting [component-based software engineering (CBSE)](https://en.wikipedia.org/wiki/Component-based_software_engineering) practices that promote reusability and maintainability.
+System Architecture establishes the foundational design principles for secure, scalable, and maintainable research environments.
+This subdomain encompasses creating secure environment designs with [defense-in-depth](https://en.wikipedia.org/wiki/Defense_in_depth_(computing)) approaches, developing microservices and API architectures that enable modular and flexible systems, implementing approaches for scalability and performance under varying workloads, creating robust enterprise solutions that meet critical requirements, and adopting [component-based software engineering (CBSE)](https://en.wikipedia.org/wiki/Component-based_software_engineering) practices that promote reusability and maintainability.
 
 ### Secure Environment Design
 
-Creates system designs that prioritise data security and privacy, compliance with 5-safes and SATRE. Involves understanding principles of secure design, applying defense-in-depth and least privilege concepts, documenting environments, implementing appropriate controls, evaluating security implications, architecting enterprise-wide secure environments, developing standards, and leading security architecture reviews and remediation.
+Creates system designs that prioritise data security and privacy, compliance with 5-safes and SATRE.
+Involves understanding principles of secure design, applying defense-in-depth and least privilege concepts, documenting environments, implementing appropriate controls, evaluating security implications, architecting enterprise-wide secure environments, developing standards, and leading security architecture reviews and remediation.
 
 === ":material-battery-10: Entry Level"
 
@@ -258,7 +272,8 @@ Creates system designs that prioritise data security and privacy, compliance wit
 
 ### Scalability & Performance
 
-Builds systems that can handle growing workloads while maintaining responsiveness. Involves understanding performance concepts and metrics, performing basic testing, designing scalable architectures, implementing caching approaches, conducting load testing, architecting high-performance systems, developing capacity planning methodologies, and leading optimization initiatives across the organization.
+Builds systems that can handle growing workloads while maintaining responsiveness.
+Involves understanding performance concepts and metrics, performing basic testing, designing scalable architectures, implementing caching approaches, conducting load testing, architecting high-performance systems, developing capacity planning methodologies, and leading optimization initiatives across the organization.
 
 === ":material-battery-10: Entry Level"
 
@@ -280,7 +295,8 @@ Builds systems that can handle growing workloads while maintaining responsivenes
 
 ### Enterprise Solution Development
 
-Creates robust systems that meet business-critical requirements. Involves understanding quality of service criteria, working with enterprise architecture concepts, explaining trade-offs between quality attributes, designing solutions that meet requirements, implementing patterns for reliability and resilience, architecting enterprise-grade solutions, and developing reference architectures.
+Creates robust systems that meet business-critical requirements.
+Involves understanding quality of service criteria, working with enterprise architecture concepts, explaining trade-offs between quality attributes, designing solutions that meet requirements, implementing patterns for reliability and resilience, architecting enterprise-grade solutions, and developing reference architectures.
 
 === ":material-battery-10: Entry Level"
 
@@ -302,7 +318,8 @@ Creates robust systems that meet business-critical requirements. Involves unders
 
 ### Component-Based Architecture
 
-Designs systems as assemblies of modular, reusable components. Involves understanding component-based design principles, working with component libraries and frameworks, developing simple components, designing modular interfaces, implementing composition approaches, optimizing for maintainability, developing enterprise frameworks, establishing standards, and leading reuse initiatives.
+Designs systems as assemblies of modular, reusable components.
+Involves understanding component-based design principles, working with component libraries and frameworks, developing simple components, designing modular interfaces, implementing composition approaches, optimizing for maintainability, developing enterprise frameworks, establishing standards, and leading reuse initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -324,7 +341,8 @@ Designs systems as assemblies of modular, reusable components. Involves understa
 
 ### Vulnerability & Patch Management
 
-Identifies, assesses, and remediates security vulnerabilities across systems and infrastructure. Involves understanding vulnerability concepts, using scanning tools, applying security updates, implementing automated processes, triaging vulnerabilities by risk, monitoring compliance, developing enterprise frameworks, establishing governance frameworks, and leading maturity initiatives.
+Identifies, assesses, and remediates security vulnerabilities across systems and infrastructure.
+Involves understanding vulnerability concepts, using scanning tools, applying security updates, implementing automated processes, triaging vulnerabilities by risk, monitoring compliance, developing enterprise frameworks, establishing governance frameworks, and leading maturity initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -346,7 +364,8 @@ Identifies, assesses, and remediates security vulnerabilities across systems and
 
 ### Configuration Management
 
-Deploys and maintains infrastructure and applications in consistent, secure, and compliant states. Involves understanding configuration concepts, applying changes using automation tools, following established procedures, implementing management processes, verifying compliance, automating remediation, developing frameworks and standards, establishing replacement processes, and leading improvement initiatives.
+Deploys and maintains infrastructure and applications in consistent, secure, and compliant states.
+Involves understanding configuration concepts, applying changes using automation tools, following established procedures, implementing management processes, verifying compliance, automating remediation, developing frameworks and standards, establishing replacement processes, and leading improvement initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -368,7 +387,8 @@ Deploys and maintains infrastructure and applications in consistent, secure, and
 
 ### High Performance Computing
 
-Provisions, configures, and securely manages high-performance computing resources and specialized hardware accelerators. Involves understanding HPC concepts, configuring access to shared resources, working with job scheduling systems, implementing secure management practices, integrating with university infrastructure, ensuring user and data segregation, developing infrastructure frameworks, establishing governance frameworks, and leading capability enhancement initiatives.
+Provisions, configures, and securely manages high-performance computing resources and specialized hardware accelerators.
+Involves understanding HPC concepts, configuring access to shared resources, working with job scheduling systems, implementing secure management practices, integrating with university infrastructure, ensuring user and data segregation, developing infrastructure frameworks, establishing governance frameworks, and leading capability enhancement initiatives.
 
 === ":material-battery-10: Entry Level"
 

--- a/docs/competency_framework/safe_technology_engineering.md
+++ b/docs/competency_framework/safe_technology_engineering.md
@@ -52,7 +52,7 @@ Develops software with security built into the code itself. Involves understandi
 
 ### Testing & Quality Assurance
 
-Validates software functionality, security, and performance before deployment. Involves creating unit tests, using testing frameworks, executing test plans, designing comprehensive strategies, implementing automated pipelines, analyzing results to improve quality, establishing processes and standards, implementing advanced testing, and driving continuous improvement initiatives.
+Validates software functionality, security, and performance before deployment. Involves creating unit tests, using testing frameworks, executing test plans, designing comprehensive approaches, implementing automated pipelines, analyzing results to improve quality, establishing processes and standards, implementing advanced testing, and driving continuous improvement initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -62,19 +62,19 @@ Validates software functionality, security, and performance before deployment. I
 
 === ":material-battery-50: Mid Level"
 
-    - Designs comprehensive test strategies including unit, integration, and security testing
+    - Designs comprehensive test plans including unit, integration, and security testing
     - Implements automated testing pipelines and monitors code coverage
     - Analyses test results to improve code quality
 
 === ":material-battery-90: Senior Level"
 
     - Establishes QA processes and standards across projects
-    - Implements advanced testing strategies for complex systems
+    - Implements advanced testing methodologies for complex systems
     - Drives quality metrics and continuous improvement initiatives
 
 ### Microservices & API Design
 
-Develops loosely coupled, independently deployable services that communicate via APIs. Involves understanding microservices principles, working with API concepts and documentation, designing appropriate service boundaries, implementing secure API gateways, developing versioning strategies, architecting enterprise API strategies, establishing best practices, and leading API security initiatives.
+Develops loosely coupled, independently deployable services that communicate via APIs. Involves understanding microservices principles, working with API concepts and documentation, designing appropriate service boundaries, implementing secure API gateways, developing versioning approaches, architecting enterprise API frameworks, establishing best practices, and leading API security initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -86,17 +86,17 @@ Develops loosely coupled, independently deployable services that communicate via
 
     - Designs microservice architectures with appropriate boundaries
     - Implements secure API gateways and authorization mechanisms
-    - Develops API versioning strategies and documentation standards
+    - Develops API versioning standards and documentation standards
 
 === ":material-battery-90: Senior Level"
 
-    - Architects enterprise API strategies and governance models
+    - Architects enterprise API frameworks and governance models
     - Establishes microservices best practices and standards
     - Leads API security initiatives and evaluates API management solutions
 
 ### Code Documentation & Reusability
 
-Creates understandable, maintainable, and reusable code. Involves writing clear comments explaining functionality, following documentation patterns, creating comprehensive explanations, designing for reusability with appropriate abstraction, implementing self-documenting principles, establishing organizational standards, developing reuse strategies, and creating knowledge sharing frameworks.
+Creates understandable, maintainable, and reusable code. Involves writing clear comments explaining functionality, following documentation patterns, creating comprehensive explanations, designing for reusability with appropriate abstraction, implementing self-documenting principles, establishing organizational standards, developing reuse approaches, and creating knowledge sharing frameworks.
 
 === ":material-battery-10: Entry Level"
 
@@ -113,12 +113,12 @@ Creates understandable, maintainable, and reusable code. Involves writing clear 
 === ":material-battery-90: Senior Level"
 
     - Establishes documentation standards and best practices for the organization
-    - Develops strategies for code reuse across projects and teams
+    - Develops methodologies for code reuse across projects and teams
     - Creates knowledge sharing frameworks and mentors others in documentation
 
 ### Artefact Management
 
-Securely stores, distributes, and controls access to software artefacts including container images, helm charts, and package repositories. Involves understanding artefact concepts, accessing repositories following procedures, working with vulnerability scanning, implementing secure registries, controlling access and scanning for threats, managing distributions, developing enterprise strategies, establishing governance processes, and leading security initiatives.
+Securely stores, distributes, and controls access to software artefacts including container images, helm charts, and package repositories. Involves understanding artefact concepts, accessing repositories following procedures, working with vulnerability scanning, implementing secure registries, controlling access and scanning for threats, managing distributions, developing enterprise frameworks, establishing governance processes, and leading security initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -134,7 +134,7 @@ Securely stores, distributes, and controls access to software artefacts includin
 
 === ":material-battery-90: Senior Level"
 
-    - Develops enterprise strategies for artefact management and governance
+    - Develops enterprise frameworks for artefact management and governance
     - Establishes automated scanning and compliance processes for all artefacts
     - Leads initiatives to enhance artefact security and supply chain integrity
 
@@ -144,7 +144,7 @@ Infrastructure & Deployment establishes the foundation for secure, scalable rese
 
 ### Cloud Infrastructure Management
 
-Designs, deploys, and manages cloud resources for secure data environments. Involves working with major providers like AWS, Azure, and GCP, provisioning resources following patterns, implementing infrastructure as code, designing secure architectures, implementing monitoring and scaling, architecting enterprise solutions, developing governance strategies, and leading cloud transformation initiatives.
+Designs, deploys, and manages cloud resources for secure data environments. Involves working with major providers like AWS, Azure, and GCP, provisioning resources following patterns, implementing infrastructure as code, designing secure architectures, implementing monitoring and scaling, architecting enterprise solutions, developing governance frameworks, and leading cloud transformation initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -161,12 +161,12 @@ Designs, deploys, and manages cloud resources for secure data environments. Invo
 === ":material-battery-90: Senior Level"
 
     - Architects enterprise-grade cloud solutions with high availability and security
-    - Develops cloud governance strategies and cost optimization approaches
+    - Develops cloud governance frameworks and cost optimization approaches
     - Leads cloud transformation initiatives and capacity planning
 
 ### Containerization & Orchestration
 
-Packages and manages applications in isolated, portable environments. Involves understanding container concepts, working with Docker and container registries, designing container-based architectures, implementing orchestration with Kubernetes or similar platforms, creating CI/CD pipelines, architecting enterprise strategies, implementing advanced security features, and establishing compliance processes.
+Packages and manages applications in isolated, portable environments. Involves understanding container concepts, working with Docker and container registries, designing container-based architectures, implementing orchestration with Kubernetes or similar platforms, creating CI/CD pipelines, architecting enterprise frameworks, implementing advanced security features, and establishing compliance processes.
 
 === ":material-battery-10: Entry Level"
 
@@ -182,13 +182,13 @@ Packages and manages applications in isolated, portable environments. Involves u
 
 === ":material-battery-90: Senior Level"
 
-    - Architects enterprise container strategies and governance models
+    - Architects enterprise container frameworks and governance models
     - Implements advanced Kubernetes features for security, scaling, and resilience
     - Establishes container security scanning and compliance processes
 
 ### Network Architecture
 
-Designs and implements secure networks for data environments. Involves understanding networking concepts like IP addressing and routing, configuring network settings, designing secure architectures with appropriate segmentation, implementing VPCs and access controls, troubleshooting issues, architecting complex multi-environment solutions, and developing network security strategies.
+Designs and implements secure networks for data environments. Involves understanding networking concepts like IP addressing and routing, configuring network settings, designing secure architectures with appropriate segmentation, implementing VPCs and access controls, troubleshooting issues, architecting complex multi-environment solutions, and developing network security policies.
 
 === ":material-battery-10: Entry Level"
 
@@ -205,12 +205,12 @@ Designs and implements secure networks for data environments. Involves understan
 === ":material-battery-90: Senior Level"
 
     - Architects complex network solutions for multi-environment deployments
-    - Develops network security strategies and implements defense-in-depth
+    - Develops network security policies and implements defense-in-depth
     - Leads network transformation initiatives and capacity planning
 
 ### Encryption & Key Management
 
-Protects data at rest and in transit using secure algorithms and robust key management practices. Involves understanding encryption concepts, implementing encryption solutions, selecting appropriate algorithms, generating and storing keys securely, managing key lifecycles, implementing access controls, developing enterprise strategies, establishing governance frameworks, and leading security enhancement initiatives.
+Protects data at rest and in transit using secure algorithms and robust key management practices. Involves understanding encryption concepts, implementing encryption solutions, selecting appropriate algorithms, generating and storing keys securely, managing key lifecycles, implementing access controls, developing enterprise frameworks, establishing governance frameworks, and leading security enhancement initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -226,13 +226,13 @@ Protects data at rest and in transit using secure algorithms and robust key mana
 
 === ":material-battery-90: Senior Level"
 
-    - Develops enterprise encryption and key management strategies
+    - Develops enterprise encryption and key management frameworks
     - Establishes governance for key lifecycle and access controls
     - Leads initiatives to enhance encryption and key management practices
 
 ## System Architecture
 
-System Architecture establishes the foundational design principles for secure, scalable, and maintainable research environments. This subdomain encompasses creating secure environment designs with [defense-in-depth](https://en.wikipedia.org/wiki/Defense_in_depth_(computing)) approaches, developing microservices and API architectures that enable modular and flexible systems, implementing strategies for scalability and performance under varying workloads, creating robust enterprise solutions that meet critical requirements, and adopting [component-based software engineering (CBSE)](https://en.wikipedia.org/wiki/Component-based_software_engineering) practices that promote reusability and maintainability.
+System Architecture establishes the foundational design principles for secure, scalable, and maintainable research environments. This subdomain encompasses creating secure environment designs with [defense-in-depth](https://en.wikipedia.org/wiki/Defense_in_depth_(computing)) approaches, developing microservices and API architectures that enable modular and flexible systems, implementing approaches for scalability and performance under varying workloads, creating robust enterprise solutions that meet critical requirements, and adopting [component-based software engineering (CBSE)](https://en.wikipedia.org/wiki/Component-based_software_engineering) practices that promote reusability and maintainability.
 
 ### Secure Environment Design
 
@@ -258,7 +258,7 @@ Creates system designs that prioritise data security and privacy, compliance wit
 
 ### Scalability & Performance
 
-Builds systems that can handle growing workloads while maintaining responsiveness. Involves understanding performance concepts and metrics, performing basic testing, designing scalable architectures, implementing caching strategies, conducting load testing, architecting high-performance systems, developing capacity planning strategies, and leading optimization initiatives across the organization.
+Builds systems that can handle growing workloads while maintaining responsiveness. Involves understanding performance concepts and metrics, performing basic testing, designing scalable architectures, implementing caching approaches, conducting load testing, architecting high-performance systems, developing capacity planning methodologies, and leading optimization initiatives across the organization.
 
 === ":material-battery-10: Entry Level"
 
@@ -269,13 +269,13 @@ Builds systems that can handle growing workloads while maintaining responsivenes
 === ":material-battery-50: Mid Level"
 
     - Designs scalable architectures for varying workloads
-    - Implements caching strategies and performance optimizations
+    - Implements caching techniques and performance optimizations
     - Conducts load testing and performance analysis
 
 === ":material-battery-90: Senior Level"
 
     - Architects high-performance systems for enterprise workloads
-    - Develops capacity planning and scaling strategies
+    - Develops capacity planning and scaling methodologies
     - Leads performance optimization initiatives across systems
 
 ### Enterprise Solution Development
@@ -302,7 +302,7 @@ Creates robust systems that meet business-critical requirements. Involves unders
 
 ### Component-Based Architecture
 
-Designs systems as assemblies of modular, reusable components. Involves understanding component-based design principles, working with component libraries and frameworks, developing simple components, designing modular interfaces, implementing composition strategies, optimizing for maintainability, developing enterprise strategies, establishing standards, and leading reuse initiatives.
+Designs systems as assemblies of modular, reusable components. Involves understanding component-based design principles, working with component libraries and frameworks, developing simple components, designing modular interfaces, implementing composition approaches, optimizing for maintainability, developing enterprise frameworks, establishing standards, and leading reuse initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -313,18 +313,18 @@ Designs systems as assemblies of modular, reusable components. Involves understa
 === ":material-battery-50: Mid Level"
 
     - Designs modular, reusable components with well-defined interfaces
-    - Implements component composition strategies for complex systems
+    - Implements component composition approaches for complex systems
     - Optimises components for maintainability and testability
 
 === ":material-battery-90: Senior Level"
 
-    - Develops enterprise component strategies and governance models
+    - Develops enterprise component frameworks and governance models
     - Establishes component design standards and best practices
     - Leads initiatives to enhance component reuse and maintainability
 
 ### Vulnerability & Patch Management
 
-Identifies, assesses, and remediates security vulnerabilities across systems and infrastructure. Involves understanding vulnerability concepts, using scanning tools, applying security updates, implementing automated processes, triaging vulnerabilities by risk, monitoring compliance, developing enterprise strategies, establishing governance frameworks, and leading maturity initiatives.
+Identifies, assesses, and remediates security vulnerabilities across systems and infrastructure. Involves understanding vulnerability concepts, using scanning tools, applying security updates, implementing automated processes, triaging vulnerabilities by risk, monitoring compliance, developing enterprise frameworks, establishing governance frameworks, and leading maturity initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -340,13 +340,13 @@ Identifies, assesses, and remediates security vulnerabilities across systems and
 
 === ":material-battery-90: Senior Level"
 
-    - Develops enterprise vulnerability management strategies
+    - Develops enterprise vulnerability management frameworks
     - Establishes automated patching frameworks and governance
     - Leads vulnerability and patch management maturity initiatives
 
 ### Configuration Management
 
-Deploys and maintains infrastructure and applications in consistent, secure, and compliant states. Involves understanding configuration concepts, applying changes using automation tools, following established procedures, implementing management processes, verifying compliance, automating remediation, developing strategies and standards, establishing replacement processes, and leading improvement initiatives.
+Deploys and maintains infrastructure and applications in consistent, secure, and compliant states. Involves understanding configuration concepts, applying changes using automation tools, following established procedures, implementing management processes, verifying compliance, automating remediation, developing frameworks and standards, establishing replacement processes, and leading improvement initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -362,13 +362,13 @@ Deploys and maintains infrastructure and applications in consistent, secure, and
 
 === ":material-battery-90: Senior Level"
 
-    - Develops configuration management strategies and standards
+    - Develops configuration management frameworks and standards
     - Establishes processes for rapid replacement of non-compliant systems
     - Leads configuration management improvement initiatives
 
 ### High Performance Computing
 
-Provisions, configures, and securely manages high-performance computing resources and specialized hardware accelerators. Involves understanding HPC concepts, configuring access to shared resources, working with job scheduling systems, implementing secure management practices, integrating with university infrastructure, ensuring user and data segregation, developing infrastructure strategies, establishing governance frameworks, and leading capability enhancement initiatives.
+Provisions, configures, and securely manages high-performance computing resources and specialized hardware accelerators. Involves understanding HPC concepts, configuring access to shared resources, working with job scheduling systems, implementing secure management practices, integrating with university infrastructure, ensuring user and data segregation, developing infrastructure frameworks, establishing governance frameworks, and leading capability enhancement initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -384,6 +384,6 @@ Provisions, configures, and securely manages high-performance computing resource
 
 === ":material-battery-90: Senior Level"
 
-    - Develops strategies for advanced computing infrastructure and capacity planning
+    - Develops methodologies for advanced computing infrastructure and capacity planning
     - Establishes governance for secure multi-tenant HPC resource usage
     - Leads initiatives to enhance computing capabilities and optimize resource utilization

--- a/docs/competency_framework/safe_technology_engineering.md
+++ b/docs/competency_framework/safe_technology_engineering.md
@@ -26,14 +26,14 @@ Involves following established processes, using version control systems, impleme
 
 === ":material-battery-90: Senior Level"
 
-    - Establishes SDLC best practices and processes for the organization
+    - Establishes SDLC best practices and processes for the organisation
     - Leads architectural decisions and ensures secure coding standards
     - Mentors team members on software engineering excellence
 
 ### Secure Coding Practices
 
 Develops software with security built into the code itself.
-Involves understanding common vulnerabilities like OWASP Top 10, applying input validation and error handling, following secure coding guidelines, identifying and mitigating security issues, implementing secure authentication and authorization, conducting security-focused code reviews, and developing organizational standards.
+Involves understanding common vulnerabilities like OWASP Top 10, applying input validation and error handling, following secure coding guidelines, identifying and mitigating security issues, implementing secure authentication and authorisation, conducting security-focused code reviews, and developing organisational standards.
 
 === ":material-battery-10: Entry Level"
 
@@ -44,19 +44,19 @@ Involves understanding common vulnerabilities like OWASP Top 10, applying input 
 === ":material-battery-50: Mid Level"
 
     - Proactively identifies and mitigates security vulnerabilities in code
-    - Implements secure authentication, authorization, and data protection mechanisms
+    - Implements secure authentication, authorisation, and data protection mechanisms
     - Conducts code reviews with a focus on security aspects
 
 === ":material-battery-90: Senior Level"
 
-    - Develops security standards and coding guidelines for the organization
+    - Develops security standards and coding guidelines for the organisation
     - Evaluates and selects appropriate security libraries and frameworks
     - Implements advanced security patterns for high-risk components
 
 ### Testing & Quality Assurance
 
 Validates software functionality, security, and performance before deployment.
-Involves creating unit tests, using testing frameworks, executing test plans, designing comprehensive approaches, implementing automated pipelines, analyzing results to improve quality, establishing processes and standards, implementing advanced testing, and driving continuous improvement initiatives.
+Involves creating unit tests, using testing frameworks, executing test plans, designing comprehensive approaches, implementing automated pipelines, analysing results to improve quality, establishing processes and standards, implementing advanced testing, and driving continuous improvement initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -79,7 +79,7 @@ Involves creating unit tests, using testing frameworks, executing test plans, de
 ### Microservices & API Design
 
 Develops loosely coupled, independently deployable services that communicate via APIs.
-Involves understanding microservices principles, working with API concepts and documentation, designing appropriate service boundaries, implementing secure API gateways, developing versioning approaches, architecting enterprise API frameworks, establishing best practices, and leading API security initiatives.
+Involves understanding microservices principles, working with API concepts and documentation, designing appropriate service boundaries, implementing secure API gateways, developing versioning approaches, architecting API frameworks, establishing best practices, and leading API security initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -90,19 +90,19 @@ Involves understanding microservices principles, working with API concepts and d
 === ":material-battery-50: Mid Level"
 
     - Designs microservice architectures with appropriate boundaries
-    - Implements secure API gateways and authorization mechanisms
+    - Implements secure API gateways and authorisation mechanisms
     - Develops API versioning standards and documentation standards
 
 === ":material-battery-90: Senior Level"
 
-    - Architects enterprise API frameworks and governance models
+    - Architects API frameworks and governance models
     - Establishes microservices best practices and standards
     - Leads API security initiatives and evaluates API management solutions
 
 ### Code Documentation & Reusability
 
 Creates understandable, maintainable, and reusable code.
-Involves writing clear comments explaining functionality, following documentation patterns, creating comprehensive explanations, designing for reusability with appropriate abstraction, implementing self-documenting principles, establishing organizational standards, developing reuse approaches, and creating knowledge sharing frameworks.
+Involves writing clear comments explaining functionality, following documentation patterns, creating comprehensive explanations, designing for reusability with appropriate abstraction, implementing self-documenting principles, establishing organisational standards, developing reuse approaches, and creating knowledge sharing policies.
 
 === ":material-battery-10: Entry Level"
 
@@ -118,14 +118,14 @@ Involves writing clear comments explaining functionality, following documentatio
 
 === ":material-battery-90: Senior Level"
 
-    - Establishes documentation standards and best practices for the organization
+    - Establishes documentation standards and best practices for the organisation
     - Develops methodologies for code reuse across projects and teams
-    - Creates knowledge sharing frameworks and mentors others in documentation
+    - Creates knowledge sharing policies and mentors others in documentation
 
 ### Artefact Management
 
 Securely stores, distributes, and controls access to software artefacts including container images, helm charts, and package repositories.
-Involves understanding artefact concepts, accessing repositories following procedures, working with vulnerability scanning, implementing secure registries, controlling access and scanning for threats, managing distributions, developing enterprise frameworks, establishing governance processes, and leading security initiatives.
+Involves understanding artefact concepts, accessing repositories following procedures, working with vulnerability scanning, implementing secure registries, controlling access and scanning for threats, managing distributions, establishing governance processes, and leading security initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -141,19 +141,19 @@ Involves understanding artefact concepts, accessing repositories following proce
 
 === ":material-battery-90: Senior Level"
 
-    - Develops enterprise frameworks for artefact management and governance
+    - Develops strategies for artefact management and governance
     - Establishes automated scanning and compliance processes for all artefacts
     - Leads initiatives to enhance artefact security and supply chain integrity
 
 ## Infrastructure & Deployment
 
 Infrastructure & Deployment establishes the foundation for secure, scalable research environments.
-This subdomain focuses on designing and managing cloud resources with appropriate security controls, implementing containerization and orchestration technologies that enable portable, isolated application environments, and creating secure network architectures with proper segmentation and access controls that collectively provide the technical infrastructure needed for protected data processing and analysis.
+This subdomain focuses on designing and managing cloud resources with appropriate security controls, implementing containerisation and orchestration technologies that enable portable, isolated application environments, and creating secure network architectures with proper segmentation and access controls that collectively provide the technical infrastructure needed for protected data processing and analysis.
 
 ### Cloud Infrastructure Management
 
 Designs, deploys, and manages cloud resources for secure data environments.
-Involves working with major providers like AWS, Azure, and GCP, provisioning resources following patterns, implementing infrastructure as code, designing secure architectures, implementing monitoring and scaling, architecting enterprise solutions, developing governance frameworks, and leading cloud transformation initiatives.
+Involves working with major providers like AWS, Azure, and GCP, provisioning resources following patterns, implementing infrastructure as code, designing secure architectures, implementing monitoring and scaling, architecting enterprise-scale solutions, developing governance frameworks, and leading cloud transformation initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -169,14 +169,14 @@ Involves working with major providers like AWS, Azure, and GCP, provisioning res
 
 === ":material-battery-90: Senior Level"
 
-    - Architects enterprise-grade cloud solutions with high availability and security
-    - Develops cloud governance frameworks and cost optimization approaches
+    - Architects enterprise-scale cloud solutions with high availability and security
+    - Develops cloud governance frameworks and cost optimisation approaches
     - Leads cloud transformation initiatives and capacity planning
 
-### Containerization & Orchestration
+### Containerisation & Orchestration
 
 Packages and manages applications in isolated, portable environments.
-Involves understanding container concepts, working with Docker and container registries, designing container-based architectures, implementing orchestration with Kubernetes or similar platforms, creating CI/CD pipelines, architecting enterprise frameworks, implementing advanced security features, and establishing compliance processes.
+Involves understanding container concepts, working with Docker and container registries, designing container-based architectures, implementing orchestration with Kubernetes or similar platforms, creating CI/CD pipelines, implementing advanced security features, and establishing compliance processes.
 
 === ":material-battery-10: Entry Level"
 
@@ -192,7 +192,7 @@ Involves understanding container concepts, working with Docker and container reg
 
 === ":material-battery-90: Senior Level"
 
-    - Architects enterprise container frameworks and governance models
+    - Designs enterprise-scale container orchestration strategy
     - Implements advanced Kubernetes features for security, scaling, and resilience
     - Establishes container security scanning and compliance processes
 
@@ -222,7 +222,7 @@ Involves understanding networking concepts like IP addressing and routing, confi
 ### Encryption & Key Management
 
 Protects data at rest and in transit using secure algorithms and robust key management practices.
-Involves understanding encryption concepts, implementing encryption solutions, selecting appropriate algorithms, generating and storing keys securely, managing key lifecycles, implementing access controls, developing enterprise frameworks, establishing governance frameworks, and leading security enhancement initiatives.
+Involves understanding encryption concepts, implementing encryption solutions, selecting appropriate algorithms, generating and storing keys securely, managing key lifecycles, implementing access controls, developing enterprise-wide governance and security enhancement initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -245,12 +245,12 @@ Involves understanding encryption concepts, implementing encryption solutions, s
 ## System Architecture
 
 System Architecture establishes the foundational design principles for secure, scalable, and maintainable research environments.
-This subdomain encompasses creating secure environment designs with [defense-in-depth](https://en.wikipedia.org/wiki/Defense_in_depth_(computing)) approaches, developing microservices and API architectures that enable modular and flexible systems, implementing approaches for scalability and performance under varying workloads, creating robust enterprise solutions that meet critical requirements, and adopting [component-based software engineering (CBSE)](https://en.wikipedia.org/wiki/Component-based_software_engineering) practices that promote reusability and maintainability.
+This subdomain encompasses creating secure environment designs with [defense-in-depth](https://en.wikipedia.org/wiki/Defense_in_depth_(computing)) approaches, developing microservices and API architectures that enable modular and flexible systems, implementing approaches for scalability and performance under varying workloads, creating robust solutions that meet critical requirements, and adopting [component-based software engineering (CBSE)](https://en.wikipedia.org/wiki/Component-based_software_engineering) practices that promote reusability and maintainability.
 
 ### Secure Environment Design
 
 Creates system designs that prioritise data security and privacy, compliance with 5-safes and SATRE.
-Involves understanding principles of secure design, applying defense-in-depth and least privilege concepts, documenting environments, implementing appropriate controls, evaluating security implications, architecting enterprise-wide secure environments, developing standards, and leading security architecture reviews and remediation.
+Involves understanding principles of secure design, applying defense-in-depth and least privilege concepts, documenting environments, implementing appropriate controls, evaluating security implications, architecting secure analytics environments, developing standards, and leading security architecture reviews and remediation.
 
 === ":material-battery-10: Entry Level"
 
@@ -266,14 +266,14 @@ Involves understanding principles of secure design, applying defense-in-depth an
 
 === ":material-battery-90: Senior Level"
 
-    - Architects enterprise-wide secure data environments
+    - Architects secure data environments
     - Develops architectural principles and standards for secure environments
     - Leads security architecture reviews and remediation efforts
 
 ### Scalability & Performance
 
 Builds systems that can handle growing workloads while maintaining responsiveness.
-Involves understanding performance concepts and metrics, performing basic testing, designing scalable architectures, implementing caching approaches, conducting load testing, architecting high-performance systems, developing capacity planning methodologies, and leading optimization initiatives across the organization.
+Involves understanding performance concepts and metrics, performing basic testing, designing scalable architectures, implementing caching approaches, conducting load testing, architecting high-performance systems, developing capacity planning methodologies, and leading optimisation initiatives across the organisation.
 
 === ":material-battery-10: Entry Level"
 
@@ -284,19 +284,19 @@ Involves understanding performance concepts and metrics, performing basic testin
 === ":material-battery-50: Mid Level"
 
     - Designs scalable architectures for varying workloads
-    - Implements caching techniques and performance optimizations
+    - Implements caching techniques and performance optimisations
     - Conducts load testing and performance analysis
 
 === ":material-battery-90: Senior Level"
 
-    - Architects high-performance systems for enterprise workloads
+    - Architects high-performance systems for demanding workloads
     - Develops capacity planning and scaling methodologies
-    - Leads performance optimization initiatives across systems
+    - Leads performance optimisation initiatives across systems
 
 ### Enterprise Solution Development
 
 Creates robust systems that meet business-critical requirements.
-Involves understanding quality of service criteria, working with enterprise architecture concepts, explaining trade-offs between quality attributes, designing solutions that meet requirements, implementing patterns for reliability and resilience, architecting enterprise-grade solutions, and developing reference architectures.
+Involves understanding quality of service criteria, working with enterprise architecture concepts, explaining trade-offs between quality attributes, designing solutions that meet requirements, implementing patterns for reliability and resilience, and developing reference architectures.
 
 === ":material-battery-10: Entry Level"
 
@@ -312,14 +312,14 @@ Involves understanding quality of service criteria, working with enterprise arch
 
 === ":material-battery-90: Senior Level"
 
-    - Architects enterprise-grade solutions balancing QoS attributes with organizational constraints
-    - Develops frameworks and reference architectures for enterprise solutions
+    - Architects large-scale solutions balancing QoS attributes with organisational constraints
+    - Develops reference architectures for enterprise solutions
     - Leads initiatives to enhance the quality and reliability of enterprise systems
 
 ### Component-Based Architecture
 
 Designs systems as assemblies of modular, reusable components.
-Involves understanding component-based design principles, working with component libraries and frameworks, developing simple components, designing modular interfaces, implementing composition approaches, optimizing for maintainability, developing enterprise frameworks, establishing standards, and leading reuse initiatives.
+Involves understanding component-based design principles, working with component libraries and frameworks, developing simple components, designing modular interfaces, implementing composition approaches, optimising for maintainability, establishing standards, and leading reuse initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -335,14 +335,14 @@ Involves understanding component-based design principles, working with component
 
 === ":material-battery-90: Senior Level"
 
-    - Develops enterprise component frameworks and governance models
+    - Leads on enterprise component architecture design
     - Establishes component design standards and best practices
     - Leads initiatives to enhance component reuse and maintainability
 
 ### Vulnerability & Patch Management
 
 Identifies, assesses, and remediates security vulnerabilities across systems and infrastructure.
-Involves understanding vulnerability concepts, using scanning tools, applying security updates, implementing automated processes, triaging vulnerabilities by risk, monitoring compliance, developing enterprise frameworks, establishing governance frameworks, and leading maturity initiatives.
+Involves understanding vulnerability concepts, using scanning tools, applying security updates, implementing automated processes, triaging vulnerabilities by risk, monitoring compliance, establishing governance frameworks, and leading maturity initiatives.
 
 === ":material-battery-10: Entry Level"
 
@@ -358,7 +358,7 @@ Involves understanding vulnerability concepts, using scanning tools, applying se
 
 === ":material-battery-90: Senior Level"
 
-    - Develops enterprise vulnerability management frameworks
+    - Develops vulnerability management initiatives
     - Establishes automated patching frameworks and governance
     - Leads vulnerability and patch management maturity initiatives
 
@@ -387,7 +387,7 @@ Involves understanding configuration concepts, applying changes using automation
 
 ### High Performance Computing
 
-Provisions, configures, and securely manages high-performance computing resources and specialized hardware accelerators.
+Provisions, configures, and securely manages high-performance computing resources and specialised hardware accelerators.
 Involves understanding HPC concepts, configuring access to shared resources, working with job scheduling systems, implementing secure management practices, integrating with university infrastructure, ensuring user and data segregation, developing infrastructure frameworks, establishing governance frameworks, and leading capability enhancement initiatives.
 
 === ":material-battery-10: Entry Level"
@@ -406,4 +406,4 @@ Involves understanding HPC concepts, configuring access to shared resources, wor
 
     - Develops methodologies for advanced computing infrastructure and capacity planning
     - Establishes governance for secure multi-tenant HPC resource usage
-    - Leads initiatives to enhance computing capabilities and optimize resource utilization
+    - Leads initiatives to enhance computing capabilities and optimize resource utilisation


### PR DESCRIPTION
**Stylistic changes**

- Improved formatting and structure for better readability.
- Reduce the number of times strategy is mentioned.
- Add FAIR principles

I can't see anything obviously amiss and certainly no mention of Quantum tech.

## Summary by Sourcery

Improve formatting and standardise terminology in the Safe Technology Engineering and Safe Data Management competency frameworks

Enhancements:
- Break long descriptions into separate lines for better readability
- Replace “strategy” with “approach” or “methodology” to reduce repetition
- Standardise terminology and UK English spelling across both documents

Documentation:
- Add FAIR principles reference to Data Cataloguing & Discovery